### PR TITLE
fixed deploy

### DIFF
--- a/build/_deploy.ts
+++ b/build/_deploy.ts
@@ -1,7 +1,7 @@
 // This is a simple generic deploy script in TypeScript that should work for most projects without modification
 // Every contract you want to deploy should have a mycontract.deploy.ts script that returns its init data
 // The script assumes that it is running from the repo root, and the directories are organized this way:
-//  ./build/ - directory for build artifacts (mycontract.cell) and deploy init data scripts (mycontract.deploy.ts)
+//  ./build/ - directory for build artifacts (mycontract.compiled.json) and deploy init data scripts (mycontract.deploy.ts)
 //  ./.env - config file with DEPLOYER_MNEMONIC - secret mnemonic of deploying wallet (will be created if not found)
 
 import axios from "axios";
@@ -84,12 +84,12 @@ async function main() {
     const initMessageCell = deployInitScript.initMessage() as Cell | null;
 
     // prepare the init code cell
-    const cellArtifact = `build/${contractName}.cell`;
-    if (!fs.existsSync(cellArtifact)) {
-      console.log(` - ERROR: '${cellArtifact}' not found, did you build?`);
+    const hexArtifact = `build/${contractName}.compiled.json`;
+    if (!fs.existsSync(hexArtifact)) {
+      console.log(` - ERROR: '${hexArtifact}' not found, did you build?`);
       process.exit(1);
     }
-    const initCodeCell = Cell.fromBoc(fs.readFileSync(cellArtifact))[0];
+    const initCodeCell = Cell.fromBoc(JSON.parse(fs.readFileSync(hexArtifact).toString()).hex)[0];
 
     // make sure the contract was not already deployed
     const newContractAddress = contractAddress({ workchain, initialData: initDataCell, initialCode: initCodeCell });


### PR DESCRIPTION
Needed to update to use json artifact instead of .cell

>>

➜  tonstarter-contracts git:(github_actions) ✗ npm run deploy

> tonstarter-contracts@0.0.0 deploy
> ts-node ./build/_deploy.ts

=================================================================
Deploy script running, let's find some contracts to deploy..

* We are working with 'testnet' (https://t.me/testgiver_ton_bot will give you test TON)

* Config file '.env' found and will be used for deployment!
 - Wallet address used to deploy from is: EQD4gS-Nj2Gjr2FYtg-s3fXUvjzKbzHGZ5_1Xe_V0-GCp0p2
 - Wallet balance is 0.4 TON, which will be used for gas

* Found root contract 'build/main.deploy.ts - let's deploy it':
 - Based on your init code+data, your new contract address is: EQC-QTihJV_B4f8M2nynateMLynaRT_uwNYnnuyy87kam-G7
 - Let's deploy the contract on-chain..
 - Deploy transaction sent successfully
 - Block explorer link: https://test.tonwhales.com/explorer/address/EQC-QTihJV_B4f8M2nynateMLynaRT_uwNYnnuyy87kam-G7
 - Waiting up to 20 seconds to check if the contract was actually deployed..
 - SUCCESS! Contract deployed successfully to address: EQC-QTihJV_B4f8M2nynateMLynaRT_uwNYnnuyy87kam-G7
 - New contract balance is now 0.018096 TON, make sure it has enough to pay rent
 - Running a post deployment test:
    Getter 'counter' = 11
    Sent 'increment' op message
    Getter 'counter' = 12