### PR TITLE
NodeJS 18 Fix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 17.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "",
   "scripts": {
     "prettier": "npx prettier --write '{test,contracts,build}/**/*.{ts,js,json}'",
-    "test": "mocha --exit test/**/*.spec.ts",
+    "test": "node --no-experimental-fetch node_modules/mocha/bin/mocha --exit test/**/*.spec.ts",
     "build": "ts-node ./build/_build.ts",
     "deploy": "ts-node ./build/_deploy.ts",
     "deploy:testnet": "ts-node ./build/_deploy.ts",


### PR DESCRIPTION
It seems that in node.js 18 ton-contract-exectuaor wasm build doesn't work, 
This issue has a good [explanation](https://github.com/Naltox/ton-contract-executor/issues/5)

`npm run test` now runs with *--no-experimental-fetch* flag