### PR TITLE
fix: update release url for fiftlib.zip

### DIFF
--- a/build/_setup.ts
+++ b/build/_setup.ts
@@ -24,7 +24,7 @@ if (fs.existsSync("/app/.glitchdotcom.json")) {
     child_process.execSync(`chmod +x ./bin/fift`);
     child_process.execSync(`wget https://github.com/ton-defi-org/ton-binaries/releases/download/ubuntu-16/func -P ./bin`);
     child_process.execSync(`chmod +x ./bin/func`);
-    child_process.execSync(`wget https://github.com/ton-defi-org/ton-binaries/releases/download/fiftlib/fiftlib.zip -P ./bin`);
+    child_process.execSync(`wget https://github.com/ton-defi-org/ton-binaries/releases/download/ubuntu-18-0.3.0/fiftlib.zip -P ./bin`);
     child_process.execSync(`unzip ./bin/fiftlib.zip -d ./bin/fiftlib`);
   }
 }


### PR DESCRIPTION
Fixes #14

Release https://github.com/ton-defi-org/ton-binaries/releases/fiftlib doesn't seem to include `fiftlib.zip` so I swapped it with https://github.com/ton-defi-org/ton-binaries/releases/ubuntu-18-0.3.0 and it seems to work just fine in Glitch.

Although, I'm not sure about potential version mismatch.